### PR TITLE
fixed exception in TXMLDataBindingItem.GetDocumentation

### DIFF
--- a/Units/XMLDataBindingGenerator.pas
+++ b/Units/XMLDataBindingGenerator.pas
@@ -1782,7 +1782,8 @@ end;
 function TXMLDataBindingItem.GetHasDocumentation: Boolean;
 begin
   Result  := Assigned(SchemaItem) and
-             (SchemaItem.Documentation.Count > 0);
+             (SchemaItem.Documentation.Count > 0) and
+             SchemaItem.Documentation.IsTextElement;
 end;
 
 


### PR DESCRIPTION
see [docwiki.embarcadero.com Xml.XMLIntf.IXMLNode.Text](https://docwiki.embarcadero.com/Libraries/Sydney/en/Xml.XMLIntf.IXMLNode.Text):

> If the node has children (other than a single DOM text node), reading or setting Text causes an exception.

GetDocumentation fails on elements like this:
```
    <xs:element name="xy" type="xyType">
      <xs:annotation>
        <xs:documentation xml:lang="de">
          <translation>xy</translation>
          <description>
            <short>kurze Beschreibung</short>
          </description>
        </xs:documentation>
      </xs:annotation>
    </xs:element>
```

This solution simply ignores every documentation with more than a single child element.