### PR TITLE
Elements in choices with nested compositors (sequences or choices) are now recognized as optional

### DIFF
--- a/Units/XMLDataBindingGenerator.pas
+++ b/Units/XMLDataBindingGenerator.pas
@@ -790,13 +790,23 @@ end;
 function TXMLDataBindingGenerator.IsChoice(AElement: IXMLElementDef): Boolean;
 var
   compositor:   IXMLElementCompositor;
-
+  parent: IXMLNode;
 begin
   Result := False;
 
-  if Supports(AElement.ParentNode, IXMLElementCompositor, compositor) then
-    Result := (compositor.CompositorType = ctChoice) and
-              (compositor.ElementDefs.Count > 1);
+  parent := AElement.ParentNode;
+  while Supports(parent, IXMLElementCompositor, compositor) do
+  begin
+    if compositor.CompositorType = ctSequence then
+    begin
+      parent := compositor.ParentNode;
+    end else
+    begin
+      Result := (compositor.CompositorType = ctChoice) and
+                (compositor.ElementDefs.Count + compositor.Compositors.Count > 1);
+      Exit;
+    end;
+  end;
 end;
 
 


### PR DESCRIPTION
Given a xsd like this
```
<?xml version="1.0" encoding="UTF-8"?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
  <xs:element name="Root">
    <xs:complexType>
      <xs:choice>
        <xs:sequence>
          <xs:element name="SimpleType" type="xs:integer"/>
        </xs:sequence>
        <xs:element name="Option2" type="xs:string"/>
      </xs:choice>
    </xs:complexType>
  </xs:element>
</xs:schema>
```
The elements SimpleType and Option2 are recognized as required elements because
1. `TXMLDataBindingGenerator.IsChoice` only checks for immediate element definitions and since only one is given it's not optional.
2. Elements in sequences never get treated as a choice and thus are also never optional.

This pullrequest fixes both issues.

I tried to add an automated test for this issue but faced quite a few problems (references to "X2UtApp", quite a few lines commented out, including the registration of the testsuite and in general a lack of understanding the structure of the tests). Help on this end would be appreciated.