### PR TITLE
fix: solves problem with handling global ref

### DIFF
--- a/Units/DelphiXMLDataBindingGenerator.pas
+++ b/Units/DelphiXMLDataBindingGenerator.pas
@@ -1808,7 +1808,7 @@ begin
   if OutputType = otMultiple then
   begin
     path      := IncludeTrailingPathDelimiter(Result);
-    fileName := ASchemaName.Replace('-', '_');
+    fileName := ASchemaName.Replace('-', '_').Replace('.', '_');
     fileName  := fileName + '.pas';
 
     if Assigned(FOnGetFileName) then

--- a/Units/XMLDataBindingGenerator.pas
+++ b/Units/XMLDataBindingGenerator.pas
@@ -875,6 +875,15 @@ begin
             Result  := TXMLDataBindingUnresolvedItem.Create(Self, AElement, dataTypeName, ifEnumeration, False);
             ASchema.AddItem(Result);
           end;
+
+          if AElement.IsGlobal then
+          begin
+            { The element is global, but only references a complex type. Keep track
+              to properly resolve references to the element. }
+            complexAliasItem      := TXMLDataBindingComplexTypeAliasItem.Create(Self, AElement, AElement.Name);
+            complexAliasItem.Item := Result;
+            ASchema.AddItem(complexAliasItem);
+          end;
         end else if simpleTypeDef.IsBuiltInType and AElement.IsGlobal then
         begin
           { The element is global, but only references a simple type. }
@@ -1313,7 +1322,10 @@ begin
             // ReplaceItem(complexAliasItem, complexAliasItem.Item);
 
             interfaceItem           := TXMLDataBindingInterface.Create(Self, complexAliasItem.SchemaItem, complexAliasItem.Name);
-            interfaceItem.BaseItem  := (complexAliasItem.Item as TXMLDataBindingInterface);
+            if complexAliasItem.Item is TXMLDataBindingInterface then
+            begin
+              interfaceItem.BaseItem  := (complexAliasItem.Item as TXMLDataBindingInterface);
+            end;
             interfaceItem.BaseName  := complexAliasItem.Item.Name;
             ASchema.AddItem(interfaceItem);
 


### PR DESCRIPTION
exapmple a declared global ref
```
<xs:element name="some_name" type="some_type_stp"></xs:element>
```
wich is includes in a complexType like this
```
<xs:element ref="nsb:some_name"/>
```
these ref was not handled handled and result in a UnresolvedElement "itElement"

this pull request resolves this issue